### PR TITLE
Require ruby 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   NewCops: enable
+  TargetRubyVersion: 2.5
   Exclude:
     - gemfiles/**/*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/veeqo/bunny-publisher/compare/v0.1.2...HEAD)
 
+### Changed
 - [#2](https://github.com/veeqo/bunny-publisher/pull/2) Use appraisal gem to control gem versions of tests matrix
+- [#3](https://github.com/veeqo/bunny-publisher/pull/3) Require ruby 2.5
 
 
 ## [0.1.2](https://github.com/veeqo/bunny-publisher/compare/v0.1.1...v0.1.2) - 2020-07-30

--- a/bunny-publisher.gemspec
+++ b/bunny-publisher.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.5'
+
   spec.add_dependency 'bunny', '~> 2.10'
 
   spec.add_development_dependency 'appraisal', '~> 2.3.0'


### PR DESCRIPTION
Previously this requirement was listed in Readme. Gemspec provides ability to set this requirement in gem metadata