### PR TITLE
Fix deprecation warnings of ruby 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [#2](https://github.com/veeqo/bunny-publisher/pull/2) Use appraisal gem to control gem versions of tests matrix
 - [#3](https://github.com/veeqo/bunny-publisher/pull/3) Require ruby 2.5
 
+### Fixed
+- [#4](https://github.com/veeqo/bunny-publisher/pull/4) Fix deprecation warnings of ruby 2.7
+
 
 ## [0.1.2](https://github.com/veeqo/bunny-publisher/compare/v0.1.1...v0.1.2) - 2020-07-30
 

--- a/lib/bunny_publisher.rb
+++ b/lib/bunny_publisher.rb
@@ -30,7 +30,7 @@ module BunnyPublisher
         include ::BunnyPublisher::Test      if config.delete_field(:test)
       end
 
-      @publisher = klass.new(config.to_h)
+      @publisher = klass.new(**config.to_h)
     end
 
     def method_missing(method_name, *args)

--- a/lib/bunny_publisher/mandatory.rb
+++ b/lib/bunny_publisher/mandatory.rb
@@ -16,7 +16,7 @@ module BunnyPublisher
     attr_reader :queue_name, :queue_options
 
     def initialize(republish_connection: nil, queue: nil, queue_options: {}, timeout_at_exit: 5, **options)
-      super(options)
+      super(**options)
 
       @queue_name = queue
       @queue_options = queue_options

--- a/spec/bunny_publisher/test/publish_spec.rb
+++ b/spec/bunny_publisher/test/publish_spec.rb
@@ -55,7 +55,7 @@ describe BunnyPublisher::Test, '#publish' do
         attr_reader :callbacks_data
 
         def initialize(options = {})
-          super
+          super(**options)
           @callbacks_data = []
         end
 


### PR DESCRIPTION
Ruby 2.7 deprecates automatic conversion from a hash to keyword arguments
https://blog.saeloun.com/2019/10/07/ruby-2-7-keyword-arguments-redesign.html