### PR TITLE
Do not share channels between threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - [#5](https://github.com/veeqo/bunny-publisher/pull/5) Test against ruby 2.7.2
 
+### Fixed
+- [#6](https://github.com/veeqo/bunny-publisher/pull/6) Do not share channels between threads
+
+
 ## [0.1.3](https://github.com/veeqo/bunny-publisher/compare/v0.1.2...v0.1.3) - 2020-09-18
 
 ### Changed


### PR DESCRIPTION
This change makes sure that each thread use its own channel as requested by official documentation of Bunny.
http://rubybunny.info/articles/concurrency.html#sharing_channels_between_threads

> Channels must not be shared between threads. When client publishes a message, at least 2 (typically 3) frames are sent on the wire:
> AMQP 0.9.1 method, basic.publish
> Message metadata
> Message payload
> This means that without synchronization on, publishing from multiple threads on a shared channel may result in frames being sent to RabbitMQ out of order
> There are other potential conflicts arising from frame interleaving. It is, however, safe to process deliveries in multiple threads if multi-message acknowledgements are not used.