### PR TITLE
Fix errors on recovery from connection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/veeqo/bunny-publisher/compare/v0.1.5...HEAD)
 
+### Fixed
+- [#8](https://github.com/veeqo/bunny-publisher/pull/8) Fix errors on recovery from connection failures
+
 
 ## [0.1.5](https://github.com/veeqo/bunny-publisher/compare/v0.1.4...v0.1.5) - 2020-11-04
 


### PR DESCRIPTION
Bunny handles connection recovery. Attempts to start a recovering connection may result weird errors like:

- `Bunny::NoFinalOctetError: Frame doesn't end with � as it must, which means the size is miscalculated`
- `Encoding::UndefinedConversionError: "\\xCE" from ASCII-8BIT to UTF-8`
- `AMQ::Protocol::FrameTypeError: Must be one of [:method, :headers, :body, :heartbeat]`
- `AMQ::Protocol::EmptyResponseError: Empty response received from the server.`
- `Bunny::TCPConnectionFailedForAllHosts: Could not establish TCP connection to any of the configured hosts`
- `Bunny::BadLengthError: Frame payload should be 505 long, but it's 20 long.`
- ``NoMethodError: undefined method `read_fully' for nil:NilClass``
- ``NoMethodError: undefined method `server_properties' for #<AMQ::Protocol::Connection::Close:0x00007f75517bb9e8>``
- ``NoMethodError: undefined method `decode_payload' for #<AMQ::Protocol::HeartbeatFrame:0x00007f14125c5940>``

Steps to reproduce the problem:
1. Run this code
```ruby
10.times.map do
  Thread.new do
    loop do
      BunnyPublisher.publish('test')
    rescue StandardError => e
      puts e.inspect
      sleep 0.01
    end
  end
end.each(&:join)
```
2. Close the connection via RabbitMQ management UI
3. Observe errors of the script

After this change the bunny-publisher will only try to start the connection with `:no_connected` status (its initial state).
It also gives some time (up to 2x of heartbeat) to recover from connection failure before publishing something to an exchange.