### PR TITLE
Stabilize publish tests

### DIFF
--- a/spec/bunny_publisher/base/publish_spec.rb
+++ b/spec/bunny_publisher/base/publish_spec.rb
@@ -129,8 +129,7 @@ describe BunnyPublisher::Base, '#publish', :rabbitmq do
           expect { publish_message }.to change { publisher.connection.status }.from(:not_connected).to(:open)
                                     .and change { messages_count }.by(1)
 
-          # rmq updates stats every 5 second so we have to wait a bit to get actual connections list via http API
-          Timeout.timeout(5.01) { sleep 0.1 while rabbitmq.list_connections == [] }
+          wait_for_connections_list
 
           expect { rabbitmq.close_connections && sleep(0.1) }.to change { connection.status }.from(:open).to(:disconnected)
 
@@ -150,8 +149,7 @@ describe BunnyPublisher::Base, '#publish', :rabbitmq do
           expect { publish_message }.to change { publisher.connection.status }.from(:not_connected).to(:open)
                                     .and change { messages_count }.by(1)
 
-          # rmq updates stats every 5 second so we have to wait a bit to get actual connections list via http API
-          Timeout.timeout(5.01) { sleep 0.1 while rabbitmq.list_connections == [] }
+          wait_for_connections_list
 
           expect { rabbitmq.close_connections && sleep(0.1) }.to change { connection.status }.from(:open).to(:disconnected)
 
@@ -182,5 +180,10 @@ describe BunnyPublisher::Base, '#publish', :rabbitmq do
 
   def messages_count
     rabbitmq.messages(queue_name, count: 999).count
+  end
+
+  def wait_for_connections_list
+    # rmq updates stats every 5 second so we have to wait a bit to get actual connections list via http API
+    Timeout.timeout(6) { sleep 0.1 while rabbitmq.list_connections == [] }
   end
 end

--- a/spec/bunny_publisher/mandatory/publish_spec.rb
+++ b/spec/bunny_publisher/mandatory/publish_spec.rb
@@ -488,8 +488,7 @@ describe BunnyPublisher::Mandatory, '#publish', :rabbitmq do
           expect(rabbitmq.list_connections).to eq []
           connection.start
 
-          # rmq updates stats every 5 second so we have to wait a bit to get actual connections list via http API
-          Timeout.timeout(5.01) { sleep 0.1 while rabbitmq.list_connections == [] }
+          wait_for_connections_list
 
           expect do
             publish_message
@@ -508,8 +507,7 @@ describe BunnyPublisher::Mandatory, '#publish', :rabbitmq do
           expect(rabbitmq.list_connections).to eq []
           connection.start
 
-          # rmq updates stats every 5 second so we have to wait a bit to get actual connections list via http API
-          Timeout.timeout(5.01) { sleep 0.1 while rabbitmq.list_connections == [] }
+          wait_for_connections_list
 
           expect { publish_message && sleep(0.2) }.to not_change { messages_count }
                                                   .and output(/Bunny::ConnectionClosedError/).to_stderr
@@ -537,8 +535,7 @@ describe BunnyPublisher::Mandatory, '#publish', :rabbitmq do
         expect(rabbitmq.list_connections).to eq []
         connection.start
 
-        # rmq updates stats every 5 second so we have to wait a bit to get actual connections list via http API
-        Timeout.timeout(5.01) { sleep 0.1 while rabbitmq.list_connections == [] }
+        wait_for_connections_list
 
         expect do
           publish_message
@@ -567,5 +564,10 @@ describe BunnyPublisher::Mandatory, '#publish', :rabbitmq do
     rabbitmq.messages(queue_name, count: 999).count
   rescue Faraday::ResourceNotFound
     0
+  end
+
+  def wait_for_connections_list
+    # rmq updates stats every 5 second so we have to wait a bit to get actual connections list via http API
+    Timeout.timeout(6) { sleep 0.1 while rabbitmq.list_connections == [] }
   end
 end

--- a/spec/bunny_publisher/mandatory/publish_spec.rb
+++ b/spec/bunny_publisher/mandatory/publish_spec.rb
@@ -493,7 +493,7 @@ describe BunnyPublisher::Mandatory, '#publish', :rabbitmq do
           expect do
             publish_message
             Timeout.timeout(20) { sleep 0.1 until publisher.send(:connection_open?) }
-            sleep(0.1)
+            sleep(0.2)
           end.to change { messages_count }.by(1)
         end
       end


### PR DESCRIPTION
Travis builds fail inconsistently because of timeout of waiting for RMQ http API to respond with connections list.